### PR TITLE
Minor Color Fix.

### DIFF
--- a/themes/expand-soft/style.css
+++ b/themes/expand-soft/style.css
@@ -32,7 +32,6 @@ table.center{
 	margin-top:-6px;
 	padding-top:10px;
 	text-align: center;
-	color:#FFFF;
 }
 table.center tr td{
 	border:1px solid #cfcfcf;


### PR DESCRIPTION
Must've missed this when I was looking over stuff.

On this theme along with the theme named silver: table.center has the color set to an invalid #ffff - while also having a light background. Thus, the text is near impossible to see.